### PR TITLE
Improve help HTML

### DIFF
--- a/help/CUSTOMPROGRAMNAME.html
+++ b/help/CUSTOMPROGRAMNAME.html
@@ -15,7 +15,7 @@
 
 <img src="basic.jpg" alt="Basic Operations" />
 
-<p>This top section is often all that a user needs to consider. With the two buttons on the left you select the USB you want to use (the box will be pre-populated with usbs that are connected when the program starts), navigate to the ISO you want, and click the Next button at the bottom of the screen. The top right button (refresh) can be used if your USB device is plugged after MX-LUM starts, while the bottom right button toggles Advanced options (below).</p>
+<p>This top section is often all that a user needs to consider. With the two buttons on the left you select the USB you want to use (the box will be pre-populated with usbs that are connected when the program starts), navigate to the ISO you want, and click the Next button at the bottom of the screen. The top right button (refresh) can be used if your USB device is plugged in after starting the program, while the bottom right button toggles Advanced options (below).</p>
 
 <h2>Options</h2>
 

--- a/help/CUSTOMPROGRAMNAME.html
+++ b/help/CUSTOMPROGRAMNAME.html
@@ -15,31 +15,31 @@
 
 <img src="basic.jpg" alt="Basic Operations" />
 
-<p>This top section is often all that a user needs to consider. With the two buttons on the left you select the USB you want to use (the box will be pre-populated with usbs that are connected when the MX-LUM starts), navigate to the ISO you want, and click the Next buttton at the bottom of the screen. The top right button (refresh) can be used if your USB device is plugged after MX-LUM starts, while the bottom right button toggles Advanced options (below).</p>
+<p>This top section is often all that a user needs to consider. With the two buttons on the left you select the USB you want to use (the box will be pre-populated with usbs that are connected when the program starts), navigate to the ISO you want, and click the Next button at the bottom of the screen. The top right button (refresh) can be used if your USB device is plugged after MX-LUM starts, while the bottom right button toggles Advanced options (below).</p>
 
 <h2>Options</h2>
 
 <img src="options.png" alt="options" />
 
-<p><strong>Dry Run</strong> simulates what will happen with the configuration chosen.  Nothing is actually written to disk.</p>
+<p><strong>Dry Run</strong> simulates what will happen with the configuration chosen. Nothing is actually written to disk.</p>
 
-<p><strong>Encrypt</strong> allows the user to create a fully encyrpted live-USB using LUKS encryption.</p>
+<p><strong>Encrypt</strong> allows the user to create a fully encrypted live-USB using LUKS encryption.</p>
 
-<p><strong>Clone an existing live system</strong> will allow the user to clone a previously created live-USB.  </p>
+<p><strong>Clone an existing live system</strong> will allow the user to clone a previously created live-USB.</p>
 
 <p><strong>Clone running live system</strong> allows live system users to clone the live system that is currently running onto a usb.</p>
 
-<p><strong>Percent of USB-device to use</strong> allows you to set a limit on how much of the device is used for the live system.  </p>
+<p><strong>Percent of USB-device to use</strong> allows you to set a limit on how much of the device is used for the live system.</p>
 
-<p><strong>Lable ext partition</strong> allows you to utilize a custom label for the fileystem on the live-USB</p>
+<p><strong>Label ext partition</strong> allows you to utilize a custom label for the filesystem on the live-USB</p>
 
 <h2>Mode</h2>
 
 <img src="mode.png" alt="mode" />
 
-<p><strong>Full-featured mode</strong> is available for users of antiX/MX family systems, including snapshots.  This mode enables all the live system features, including peristence and other features requiring writable media to function (save options, etc…).</p>
+<p><strong>Full-featured mode</strong> is available for users of antiX/MX family systems, including snapshots. This mode enables all the live system features, including persistence and other features requiring writable media to function (save options, etc).</p>
 
-<p><strong>Image mode</strong> is the fallback for non-antiX/MX family isos, and utilizes a &#8220;dd&#8221; backend to create an exact copy of a source iso onto the target media.  This is similar to utilities like etcher or using &#8220;dd&#8221; directly from the commandline.  Image Mode has some sanity checks to help the user write data only to the target media. </p>
+<p><strong>Image mode</strong> is the fallback for non-antiX/MX family isos, and utilizes a &#8220;dd&#8221; backend to create an exact copy of a source iso onto the target media. This is similar to utilities like etcher or using &#8220;dd&#8221; directly from the commandline. Image Mode has some sanity checks to help the user write data only to the target media.</p>
 
 <h2>Advanced options</h2>
 
@@ -47,29 +47,29 @@
 
 <p>The advanced options are mostly for testing and develoment work, although some might be useful to end users in particular scenarios.</p>
 
-<p><strong>GPT Paritioning </strong> forces the use of gpt partition tables on the live-usb insted of the default &#8220;msdos&#8221; partition table.  Some systems may not boot from the live-USB if gpt is used, and this is only really usefull in UEFI environements.</p>
+<p><strong>GPT Partitioning </strong> forces the use of gpt partition tables on the live-usb insted of the default &#8220;msdos&#8221; partition table. Some systems may not boot from the live-USB if gpt is used, and this is only really useful in UEFI environments.</p>
 
-<p><strong>Update</strong> allows the user to update an existing live-USB with a new iso.  this is not useful if persistence is in use, and is usually only used for testing and development work.</p>
+<p><strong>Update</strong> allows the user to update an existing live-USB with a new iso. This is not useful if persistence is in use, and is usually only used for testing and development work.</p>
 
 <p><strong>Save the original boot directory when updating a live-USB</strong> is useful when an encrypted environment is in use and is generally only used for testing and development.</p>
 
 <p><strong>Temporarily disable automounting</strong> is useful to disable antiX automounting system, and has no effect in MX.</p>
 
-<p><strong>Ignore USB/removable check</strong> skips the final sanity checks to make sure a target media is a removable device.</p>
+<p><strong>Ignore USB/removable check</strong> skips the final sanity checks to make sure the target is a removable device.</p>
 
 <p><strong>Set pmbr_boot disk flag</strong> sets the legacy boot flag on gpt partitions, but disables booting from UEFI systems.</p>
 
-<p><strong>Keep syslinux files</strong> will disable reinstallation of syslinux boot loader on an exisitng live-USB, and typically only matters for development work.</p>
+<p><strong>Keep syslinux files</strong> will disable reinstallation of syslinux boot loader on an existing live-USB, and typically only matters for development work.</p>
 
-<p><strong>Make ext filesystem even if one exists</strong>  forces creation of a new ext filesystem even if one exists already.  Generally only useful for testing and development.</p>
+<p><strong>Make ext filesystem even if one exists</strong> forces creation of a new ext filesystem even if one exists already. Generally only useful for testing and development.</p>
 
 <p><strong>Resources</strong></p>
 
 <p>BitJam&#8217;s detailed notes can be found <a href="https://github.com/BitJam/live-usb-maker/blob/master/README.md">here</a>.<br> Development history: BitJam (antiX), Dolphin_Oracle, adrian</p>
 
-<p>License: ?</p>
+<p>License: GPLv3</p>
 
-<p>v. 20181104</p>
+<p>v. 20240315</p>
 
 </body>
 </html>


### PR DESCRIPTION
Some trivialities.

* fix spellings
* remove excess spaces
* name the licence
* say `program` instead of `MX-LUM` (never expanded).

Not addressed: usb/USB, ext/EXT, gpt/GPT, etc.